### PR TITLE
Fix build on Windows ARM64

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,6 +57,7 @@ jobs:
           - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release'}
           - {os: macos-latest, r: 'release'}
           - {os: windows-latest, r: 'release'}
+          - {os: windows-11-arm, r: 'release', rust-target: 'aarch64-pc-windows-gnullvm'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -69,6 +70,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.config.rust-target }}
 
       - name: Vendor Rust dependencies
         run: |

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
-TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+TARGET = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" "../tools/rustarch.R")
 
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/release

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "5048aeecde83b7455a63b44aa54da5321d6171cff2adb8a5959849e142e5e4aa"
 
 [[package]]
 name = "extendr-api"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea54977c6e37236839ffcbc20b5dcea58aa32ae43fbef54a81e1011dc6b19061"
+checksum = "e002a15028421248374d3beb66d1802ce70d738b666a043a1f4dfffad14bc595"
 dependencies = [
  "extendr-ffi",
  "extendr-macros",
@@ -89,15 +89,15 @@ dependencies = [
 
 [[package]]
 name = "extendr-ffi"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76777174a82bdb3e66872f580687d3d0143eed1df9b9cd72b321b9596a23ca7"
+checksum = "acf3ace33b895bdfc13d02fd7486b26dc71078c256f3399f6272f8bd70fc3a1e"
 
 [[package]]
 name = "extendr-macros"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661cc4ae29de9c4dafe16cfcbda1dbb9f31bd2568f96ebad232cc1f9bcc8b04d"
+checksum = "f6b27baf9abffe403f3051efea3c19a0f315be9ec5f1c80efbade1aee5ccccbc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["staticlib"]
 name = "tinyimg"
 
 [dependencies]
-extendr-api = "0.8.1"
+extendr-api = "0.8.2"
 mozjpeg = { version = "0.10", default-features = false }
 oxipng = { version = "9.1", default-features = false, features = ["filetime", "zopfli"] }
 exoquant = "0.2.0"

--- a/tools/rustarch.R
+++ b/tools/rustarch.R
@@ -1,0 +1,13 @@
+# See notes in FAQ about ARM64 support:
+# https://github.com/r-rust/faq#does-rust-support-windows-on-arm64-aarch64
+arch <- if(grepl("aarch", R.version$platform)){
+  "aarch64-pc-windows-gnullvm"
+} else if(grepl("clang", Sys.getenv('R_COMPILED_BY'))){
+  "x86_64-pc-windows-gnullvm"
+} else if(grepl("i386", R.version$platform)){
+  "i686-pc-windows-gnu"
+} else {
+  "x86_64-pc-windows-gnu"
+}
+
+cat(arch)


### PR DESCRIPTION
This fixes the build on Windows ARM64.

Before: https://github.com/r-universe/cran/actions/runs/30699935452/attempts/1
After: https://github.com/r-universe/cran/actions/runs/30699935452/job/91416936545

It bumps `extendr-api` to 0.8.2 (which supports Windows ARM64) and honours `CARGO_BUILD_TARGET` so the correct `--target` is passed on Windows arm64 (the old `$(WIN)` substitution produced an empty triple there).

For more details see https://github.com/r-devel/windows-arm64